### PR TITLE
Fix the path to the protocol description.

### DIFF
--- a/lib/aliyun-ots.js
+++ b/lib/aliyun-ots.js
@@ -20,7 +20,7 @@ bindCallback = nodefn.bindCallback;
 
 request = nodefn.lift(requestFn);
 
-schemaDesc = new Schema(fs.readFileSync('./ots_protocol.desc'));
+schemaDesc = new Schema(fs.readFileSync(path.join(__dirname, '../ots_protocol.desc')));
 
 schemas = {};
 

--- a/src/aliyun-ots.coffee
+++ b/src/aliyun-ots.coffee
@@ -12,7 +12,7 @@ bindCallback = nodefn.bindCallback
 request = nodefn.lift requestFn
 
 
-schemaDesc = new Schema fs.readFileSync './ots_protocol.desc'
+schemaDesc = new Schema fs.readFileSync path.join __dirname, '../ots_protocol.desc'
 
 schemas = {}
 schema = (name) ->


### PR DESCRIPTION
The old code causes file-not-found error when using the package as a dependency.